### PR TITLE
Command.cs: check for a keypress before blocking to read it

### DIFF
--- a/OpenDirectoryDownloader/Command.cs
+++ b/OpenDirectoryDownloader/Command.cs
@@ -107,6 +107,10 @@ namespace OpenDirectoryDownloader
                     }
                     else
                     {
+                        if (!Console.KeyAvailable)
+                        {
+                            continue;
+                        }
                         ConsoleKey keyPressed = Console.ReadKey(intercept: true).Key;
                         //Console.WriteLine($"Pressed (Console.ReadKey(): {keyPressed}");
 


### PR DESCRIPTION
Fixes #43 

This PR resolves a deadlock in presumably any `Console.Write` during the scan, which happened due to a blocking call to `Console.ReadKey`. `ReadKey` not only blocks indefinitely, but also locks to console, preventing any other operations from taking place. `Console.KeyAvailable` returns immediately, so it can be used to check for keystrokes before calling `ReadKey`.

Tested on my setup shared in #43. Note that there may still be issues with redirected stdin, because there's also a blocking call here: 
https://github.com/KoalaBear84/OpenDirectoryDownloader/blob/182653317beee57148ec790f88e8ced71355cc2b/OpenDirectoryDownloader/Command.cs#L59