### PR TITLE
Github Actions Revamp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
             os: macos-latest
             target: osx-x64
 
-    runs-on: ${ matrix.os }
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,33 +22,28 @@ jobs:
     
     strategy:
       matrix:
-        kind: 
-          - linux
+        target: 
+          - linux-x64
           - linux-arm
           - linux-arm64
-          - windows
-          - mac
+          - win-x64
+          - osx-x64
         self-contained:
           - non-self-contained
           - self-contained
         include:
-          - kind: linux
+          - target: linux-x64
             os: ubuntu-latest
-            target: linux-x64
-          - kind: linux-arm
+          - target: linux-arm
             os: ubuntu-latest
-            target: linux-arm
-          - kind: linux-arm64
+          - target: linux-arm64
             os: ubuntu-latest
-            target: linux-arm64
-          - kind: windows
+          - target: win-x64
             os: windows-latest
-            target: win-x64
-          - kind: mac
+          - target: osx-x64
             os: macos-latest
-            target: osx-x64
           
-          - self-contained: non-self-contained
+          - self-contained: normal
             build_args: --no-self-contained
             suffix: ""
           - self-contained: self-contained
@@ -81,16 +76,16 @@ jobs:
       run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime ${{ matrix.target }} ${{ matrix.build_args }} -p:PublishSingleFile=true --output ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
 
     - name: Set executable bit (linux only)
-      if: ${{ matrix.os == 'linux' }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: chmod +x ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}/OpenDirectoryDownloader
 
     - name: Zipping
       run: |
         7z a OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
-        # 7z is installed in all environments and supports unix permissions while compresisng (but not while decompressing!)
+        # 7z is installed in all environments and supports unix permissions while compressing (but not while decompressing!)
 
-    - name: Upload artifact for docker job (linux non-self-contained only)
-      if: ${{ matrix.kind == 'linux' && matrix.self-contained == 'non-self-contained' }}
+    - name: Upload artifact for docker job (linux-x64 normal only)
+      if: ${{ matrix.target == 'linux-x64' && matrix.self-contained == 'normal' }}
       uses: actions/upload-artifact@v2
       with:
         name: linux-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,63 +28,32 @@ jobs:
           - linux-arm64
           - windows
           - mac
-          - linux-self-contained
-          - linux-arm-self-contained
-          - linux-arm64-self-contained
-          - windows-self-contained
-          - mac-self-contained
+        self-contained:
+          - true
+          - false
         include:
           - kind: linux
             os: ubuntu-latest
             target: linux-x64
-            build_args: --no-self-contained
-            suffix: ""
           - kind: linux-arm
             os: ubuntu-latest
             target: linux-arm
-            build_args: --no-self-contained
-            suffix: ""
           - kind: linux-arm64
             os: ubuntu-latest
             target: linux-arm64
-            build_args: --no-self-contained
-            suffix: ""
           - kind: windows
             os: windows-latest
             target: win-x64
-            build_args: --no-self-contained
-            suffix: ""
           - kind: mac
             os: macos-latest
             target: osx-x64
+          
+          - self-contained: false
             build_args: --no-self-contained
             suffix: ""
-
-          - kind: linux-self-contained
-            os: ubuntu-latest
-            target: linux-x64
+          - self-contained: true
             build_args: --self-contained=true
-            suffix: -self-contained
-          - kind: linux-arm-self-contained
-            os: ubuntu-latest
-            target: linux-arm
-            build_args: --self-contained=true
-            suffix: -self-contained
-          - kind: linux-arm64-self-contained
-            os: ubuntu-latest
-            target: linux-arm64
-            build_args: --self-contained=true
-            suffix: -self-contained
-          - kind: windows-self-contained
-            os: windows-latest
-            target: win-x64
-            build_args: --self-contained=true
-            suffix: -self-contained
-          - kind: mac-self-contained
-            os: macos-latest
-            target: osx-x64
-            build_args: --self-contained=true
-            suffix: -self-contained
+            suffix: "-self-contained"
 
     runs-on: ${{ matrix.os }}
 
@@ -118,7 +87,7 @@ jobs:
         dest: OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip
 
     - name: Upload artifact for docker job (linux only)
-      if: matrix.kind == 'linux'
+      if: ${{ matrix.kind == 'linux' && matrix.self-contained == false }}
       uses: actions/upload-artifact@v2
       with:
         name: linux-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Get version info
       id: get_version
 #      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
-      run: echo ::set-output name=VERSION::"${{ hashFiles('.github/workflows/main.yml') }}" # TODO: Change back
+      run: echo ::set-output name=VERSION::"2" # TODO: Change back
       
     - name: Build with dotnet
       run: dotnet build OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Get version info
       id: get_version
 #      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
-      run: echo ::set-output name=VERSION::"${{ hashFiles(.github/workflows/main.yml) }}" # TODO: Change back
+      run: echo ::set-output name=VERSION::"${{ hashFiles('.github/workflows/main.yml') }}" # TODO: Change back
       
     - name: Build with dotnet
       run: dotnet build OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-${{ matrix.target }.zip
+        asset_path: ./OpenDirectoryDownloader-${{ matrix.target }}.zip
         asset_name: OpenDirectoryDownloader-${{ matrix.target }}.zip
         asset_content_type: application/zip
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
       run: dotnet test OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }}
 
     - name: Publish with dotnet
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime ${{ matrix.target }} ${{ matrix.build_args }} --p:PublishSingleFile=true --output ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
+      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime ${{ matrix.target }} ${{ matrix.build_args }} -p:PublishSingleFile=true --output ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
 
     - name: Zipping
       uses: papeloto/action-zip@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,11 +79,10 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         chmod +x ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}/OpenDirectoryDownloader
-        ls -lah ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
 
     - name: Zipping
       run: |
-        7z a OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
+        7z a OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}/*
         # 7z is installed in all environments and supports unix permissions while compressing (but not while decompressing!)
 
     - name: Upload artifact for docker job (linux-x64 normal only)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,10 @@ jobs:
     - name: Publish with dotnet
       run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime ${{ matrix.target }} ${{ matrix.build_args }} -p:PublishSingleFile=true --output ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
 
+    - name: Set executable bit (linux only)
+      if: ${{ matrix.os == 'linux' }}
+      run: chmod +x ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}/OpenDirectoryDownloader
+
     - name: Zipping
       run: |
         7z a OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,16 @@ jobs:
             target: linux-x64
             build_args: --no-self-contained
             suffix: ""
+          - kind: linux-arm
+            os: ubuntu-latest
+            target: linux-arm
+            build_args: --no-self-contained
+            suffix: ""
+          - kind: linux-arm64
+            os: ubuntu-latest
+            target: linux-arm64
+            build_args: --no-self-contained
+            suffix: ""
           - kind: windows
             os: windows-latest
             target: win-x64
@@ -43,6 +53,16 @@ jobs:
           - kind: linux-self-contained
             os: ubuntu-latest
             target: linux-x64
+            build_args: --self-contained=true
+            suffix: -self-contained
+          - kind: linux-arm-self-contained
+            os: ubuntu-latest
+            target: linux-arm
+            build_args: --self-contained=true
+            suffix: -self-contained
+          - kind: linux-arm64-self-contained
+            os: ubuntu-latest
+            target: linux-arm64
             build_args: --self-contained=true
             suffix: -self-contained
           - kind: windows-self-contained

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,12 +81,11 @@ jobs:
       run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime ${{ matrix.target }} ${{ matrix.build_args }} -p:PublishSingleFile=true --output ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
 
     - name: Zipping
-      uses: papeloto/action-zip@v1
-      with:
-        files: ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
-        dest: OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip
+      run: |
+        7z a OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
+        # 7z is installed in all environments and supports unix permissions while compresisng (but not while decompressing!)
 
-    - name: Upload artifact for docker job (linux only)
+    - name: Upload artifact for docker job (linux non-self-contained only)
       if: ${{ matrix.kind == 'linux' && matrix.self-contained == 'non-self-contained' }}
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
           OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip
 
 
-  create_release:
+  release:
     needs: build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,7 @@ jobs:
         prerelease: false
         body: ${{ github.event.head_commit.message }}
         files: |
-          OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip
+          OpenDirectoryDownloader-*.zip
     
 
   docker:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,16 +5,36 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+    branches:
+      - actions # MCO's feature branch, remove before merging
   workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   build:
 
-    runs-on: windows-latest
-
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
+    
+    strategy:
+      matrix:
+        kind: ['linux', 'windows', 'mac']
+        include:
+          - kind: linux
+            os: ubuntu-latest
+            target: linux-x64
+          - kind: windows
+            os: windows-latest
+            target: win-x64
+          - kind: mac
+            os: macos-latest
+            target: osx-x64
+
+    runs-on: ${ matrix.os }
 
     steps:
     - name: Checkout
@@ -25,134 +45,45 @@ jobs:
       with:
         dotnet-version: 5.0.100
 
-
-
     - name: Get version info
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
-      shell: bash
       
-
-
     - name: Build with dotnet
       run: dotnet build OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }}
 
     - name: Test with dotnet
       run: dotnet test OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }}
 
-    
 
-    - name: Publish with dotnet win-x64
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime win-x64 --no-self-contained -p:PublishSingleFile=true --output ./OpenDirectoryDownloader-win-x64
+    - name: Publish with dotnet
+      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime ${{ matrix.target }} --no-self-contained -p:PublishSingleFile=true --output ./OpenDirectoryDownloader-${{ matrix.target }}
 
-    - name: Zipping win-x64
+    - name: Zipping
       uses: papeloto/action-zip@v1
       with:
         files: ./OpenDirectoryDownloader-win-x64
         dest: OpenDirectoryDownloader-win-x64.zip
 
-    - name: Publish with dotnet win-x64 (self-contained)
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime win-x64 --self-contained=true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:IncludeNativeLibrariesForSelfExtract=true --output ./OpenDirectoryDownloader-win-x64-self-contained
 
-    - name: Zipping win-x64 (self-contained)
+    - name: Publish with dotnet (self-contained)
+      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime ${{ matrix.target }} --self-contained=true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:IncludeNativeLibrariesForSelfExtract=true --output ./OpenDirectoryDownloader-${{ matrix.target }}-self-contained
+
+    - name: Zipping (self-contained)
       uses: papeloto/action-zip@v1
       with:
-        files: ./OpenDirectoryDownloader-win-x64-self-contained
-        dest: OpenDirectoryDownloader-win-x64-self-contained.zip
+        files: ./OpenDirectoryDownloader-${{ matrix.target }}-self-contained
+        dest: OpenDirectoryDownloader-${{ matrix.target }}-self-contained.zip
 
 
-
-    - name: Publish with dotnet linux-x64
-      run: |
-        dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime linux-x64 --no-self-contained -p:PublishSingleFile=true --output ./OpenDirectoryDownloader-linux-x64
-        chmod +x ./OpenDirectoryDownloader-linux-x64/OpenDirectoryDownloader
-
-    - name: Zipping linux-x64
-      uses: papeloto/action-zip@v1
-      with:
-        files: ./OpenDirectoryDownloader-linux-x64
-        dest: OpenDirectoryDownloader-linux-x64.zip
-
-    - name: Publish with dotnet linux-x64 (self-contained)
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime linux-x64 --self-contained=true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:IncludeNativeLibrariesForSelfExtract=true --output ./OpenDirectoryDownloader-linux-x64-self-contained
-
-    - name: Zipping linux-x64 (self-contained)
-      uses: papeloto/action-zip@v1
-      with:
-        files: ./OpenDirectoryDownloader-linux-x64-self-contained
-        dest: OpenDirectoryDownloader-linux-x64-self-contained.zip
-
-
-
-    - name: Upload artifact linux-x64
+    - name: Upload artifact for docker job (linux only)
+      if: matrix.kind == 'linux'
       uses: actions/upload-artifact@v2
       with:
         name: linux-x64
         path: |
-          OpenDirectoryDownloader-linux-x64.zip
+          OpenDirectoryDownloader-${{ matrix.target }}.zip
           Dockerfile
-
-
-
-    - name: Publish with dotnet linux-arm64
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime linux-arm64 --no-self-contained -p:PublishSingleFile=true --output ./OpenDirectoryDownloader-linux-arm64
-
-    - name: Zipping linux-arm64
-      uses: papeloto/action-zip@v1
-      with:
-        files: ./OpenDirectoryDownloader-linux-arm64
-        dest: OpenDirectoryDownloader-linux-arm64.zip
-
-    - name: Publish with dotnet linux-arm64 (self-contained)
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime linux-arm64 --self-contained=true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:IncludeNativeLibrariesForSelfExtract=true --output ./OpenDirectoryDownloader-linux-arm64-self-contained
-
-    - name: Zipping linux-arm64 (self-contained)
-      uses: papeloto/action-zip@v1
-      with:
-        files: ./OpenDirectoryDownloader-linux-arm64-self-contained
-        dest: OpenDirectoryDownloader-linux-arm64-self-contained.zip
-
-
-
-    - name: Publish with dotnet linux-arm
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime linux-arm --no-self-contained -p:PublishSingleFile=true --output ./OpenDirectoryDownloader-linux-arm
-
-    - name: Zipping linux-arm
-      uses: papeloto/action-zip@v1
-      with:
-        files: ./OpenDirectoryDownloader-linux-arm
-        dest: OpenDirectoryDownloader-linux-arm.zip
-
-    - name: Publish with dotnet linux-arm (self-contained)
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime linux-arm --self-contained=true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:IncludeNativeLibrariesForSelfExtract=true --output ./OpenDirectoryDownloader-linux-arm-self-contained
-
-    - name: Zipping linux-arm (self-contained)
-      uses: papeloto/action-zip@v1
-      with:
-        files: ./OpenDirectoryDownloader-linux-arm-self-contained
-        dest: OpenDirectoryDownloader-linux-arm-self-contained.zip
-
-
-
-    - name: Publish with dotnet osx-x64
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime osx-x64 --no-self-contained -p:PublishSingleFile=true --output ./OpenDirectoryDownloader-osx-x64
-
-    - name: Zipping osx-x64
-      uses: papeloto/action-zip@v1
-      with:
-        files: ./OpenDirectoryDownloader-osx-x64
-        dest: OpenDirectoryDownloader-osx-x64.zip
-
-    - name: Publish with dotnet osx-x64 (self-contained)
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime osx-x64 --self-contained=true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:IncludeNativeLibrariesForSelfExtract=true --output ./OpenDirectoryDownloader-osx-x64-self-contained
-
-    - name: Zipping osx-x64 (self-contained)
-      uses: papeloto/action-zip@v1
-      with:
-        files: ./OpenDirectoryDownloader-osx-x64-self-contained
-        dest: OpenDirectoryDownloader-osx-x64-self-contained.zip
-
-
 
     - name: Create release
       id: create_release
@@ -165,116 +96,28 @@ jobs:
         draft: false
         prerelease: false
         body: ${{ github.event.head_commit.message }}
-
-
-
-    - name: Upload Release Asset win-x64
+        
+    - name: Upload Release Asset
       uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-win-x64.zip
-        asset_name: OpenDirectoryDownloader-win-x64.zip
-        asset_content_type: application/zip
-
-    - name: Upload Release Asset win-x64 (self-contained)
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-win-x64-self-contained.zip
-        asset_name: OpenDirectoryDownloader-win-x64-self-contained.zip
-        asset_content_type: application/zip
-
-
-
-    - name: Upload Release Asset linux-x64
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-linux-x64.zip
-        asset_name: OpenDirectoryDownloader-linux-x64.zip
-        asset_content_type: application/zip
-
-    - name: Upload Release Asset linux-x64 (self-contained)
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-linux-x64-self-contained.zip
-        asset_name: OpenDirectoryDownloader-linux-x64-self-contained.zip
-        asset_content_type: application/zip
-
-
-
-    - name: Upload Release Asset linux-arm64
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-linux-arm64.zip
-        asset_name: OpenDirectoryDownloader-linux-arm64.zip
-        asset_content_type: application/zip
-
-    - name: Upload Release Asset linux-arm64 (self-contained)
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-linux-arm64-self-contained.zip
-        asset_name: OpenDirectoryDownloader-linux-arm64-self-contained.zip
-        asset_content_type: application/zip
-
-
-
-    - name: Upload Release Asset linux-arm
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-linux-arm.zip
-        asset_name: OpenDirectoryDownloader-linux-arm.zip
-        asset_content_type: application/zip
-
-    - name: Upload Release Asset linux-arm (self-contained)
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-linux-arm-self-contained.zip
-        asset_name: OpenDirectoryDownloader-linux-arm-self-contained.zip
-        asset_content_type: application/zip
-
-
-
-    - name: Upload Release Asset osx-x64
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-osx-x64.zip
-        asset_name: OpenDirectoryDownloader-osx-x64.zip
+        asset_path: ./OpenDirectoryDownloader-${{ matrix.target }.zip
+        asset_name: OpenDirectoryDownloader-${{ matrix.target }}.zip
         asset_content_type: application/zip
         
-    - name: Upload Release Asset osx-x64 (self-contained)
+    - name: Upload Release Asset (self-contained)
       uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-osx-x64-self-contained.zip
-        asset_name: OpenDirectoryDownloader-osx-x64-self-contained.zip
+        asset_path: ./OpenDirectoryDownloader-${{ matrix.target }}-self-contained.zip
+        asset_name: OpenDirectoryDownloader-${{ matrix.target }}-self-contained.zip
         asset_content_type: application/zip
+
+
 
   docker:
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-    branches:
-      - actions # MCO's feature branch, remove before merging
   workflow_dispatch:
 
 defaults:
@@ -63,8 +61,7 @@ jobs:
 
     - name: Get version info
       id: get_version
-#      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
-      run: echo ::set-output name=VERSION::"3" # TODO: Change back
+      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
       
     - name: Build with dotnet
       run: dotnet build OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,17 @@ jobs:
     
     strategy:
       matrix:
-        kind: ['linux', 'windows', 'mac']
+        kind: 
+          - linux
+          - linux-arm
+          - linux-arm64
+          - windows
+          - mac
+          - linux-self-contained
+          - linux-arm-self-contained
+          - linux-arm64-self-contained
+          - windows-self-contained
+          - mac-self-contained
         include:
           - kind: linux
             os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,8 @@ jobs:
 
     - name: Get version info
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+#      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+      run: echo ::set-output name=VERSION::"1.0" # TODO: Change back
       
     - name: Build with dotnet
       run: dotnet build OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,9 @@ jobs:
 
     - name: Set executable bit (linux only)
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: chmod +x ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}/OpenDirectoryDownloader
+      run: |
+        chmod +x ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}/OpenDirectoryDownloader
+        ls -lah ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
 
     - name: Zipping
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Get version info
       id: get_version
 #      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
-      run: echo ::set-output name=VERSION::"2" # TODO: Change back
+      run: echo ::set-output name=VERSION::"3" # TODO: Change back
       
     - name: Build with dotnet
       run: dotnet build OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }}
@@ -88,7 +88,7 @@ jobs:
 
     - name: Create release
       id: create_release
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,8 +63,8 @@ jobs:
     - name: Zipping
       uses: papeloto/action-zip@v1
       with:
-        files: ./OpenDirectoryDownloader-{{ matrix.target }}
-        dest: OpenDirectoryDownloader-{{ matrix.target }}.zip
+        files: ./OpenDirectoryDownloader-${{ matrix.target }}
+        dest: OpenDirectoryDownloader-${{ matrix.target }}.zip
 
 
     - name: Publish with dotnet (self-contained)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,8 @@ jobs:
           - windows
           - mac
         self-contained:
-          - true
-          - false
+          - non-self-contained
+          - self-contained
         include:
           - kind: linux
             os: ubuntu-latest
@@ -48,10 +48,10 @@ jobs:
             os: macos-latest
             target: osx-x64
           
-          - self-contained: false
+          - self-contained: non-self-contained
             build_args: --no-self-contained
             suffix: ""
-          - self-contained: true
+          - self-contained: self-contained
             build_args: --self-contained=true
             suffix: "-self-contained"
 
@@ -87,7 +87,7 @@ jobs:
         dest: OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip
 
     - name: Upload artifact for docker job (linux only)
-      if: ${{ matrix.kind == 'linux' && matrix.self-contained == false }}
+      if: ${{ matrix.kind == 'linux' && matrix.self-contained == 'non-self-contained' }}
       uses: actions/upload-artifact@v2
       with:
         name: linux-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           - win-x64
           - osx-x64
         self-contained:
-          - non-self-contained
+          - normal
           - self-contained
         include:
           - target: linux-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,8 +63,8 @@ jobs:
     - name: Zipping
       uses: papeloto/action-zip@v1
       with:
-        files: ./OpenDirectoryDownloader-win-x64
-        dest: OpenDirectoryDownloader-win-x64.zip
+        files: ./OpenDirectoryDownloader-{{ matrix.target }}
+        dest: OpenDirectoryDownloader-{{ matrix.target }}.zip
 
 
     - name: Publish with dotnet (self-contained)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Get version info
       id: get_version
 #      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
-      run: echo ::set-output name=VERSION::"1.0" # TODO: Change back
+      run: echo ::set-output name=VERSION::"${{ hashFiles(.github/workflows/main.yml) }}" # TODO: Change back
       
     - name: Build with dotnet
       run: dotnet build OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,8 +94,24 @@ jobs:
           OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip
           Dockerfile
 
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: all-artifacts
+        path: |
+          OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip
+
+
+  create_release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: all-artifacts
     - name: Create release
-      id: create_release
       uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -107,7 +123,7 @@ jobs:
         body: ${{ github.event.head_commit.message }}
         files: |
           OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip
-
+    
 
   docker:
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,13 +108,17 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: all-artifacts
+
+    - name: Get tag info
+      id: tag_info
+      run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
     - name: Create release
       uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        name: OpenDirectoryDownloader ${{ github.ref }}
+        tag_name: ${{ steps.tag_info.outputs.SOURCE_TAG }}
+        name: OpenDirectoryDownloader ${{ steps.tag_info.outputs.SOURCE_TAG }}
         draft: false
         prerelease: false
         body: ${{ github.event.head_commit.message }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,12 +27,34 @@ jobs:
           - kind: linux
             os: ubuntu-latest
             target: linux-x64
+            build_args: --no-self-contained
+            suffix: ""
           - kind: windows
             os: windows-latest
             target: win-x64
+            build_args: --no-self-contained
+            suffix: ""
           - kind: mac
             os: macos-latest
             target: osx-x64
+            build_args: --no-self-contained
+            suffix: ""
+
+          - kind: linux-self-contained
+            os: ubuntu-latest
+            target: linux-x64
+            build_args: --self-contained=true
+            suffix: -self-contained
+          - kind: windows-self-contained
+            os: windows-latest
+            target: win-x64
+            build_args: --self-contained=true
+            suffix: -self-contained
+          - kind: mac-self-contained
+            os: macos-latest
+            target: osx-x64
+            build_args: --self-contained=true
+            suffix: -self-contained
 
     runs-on: ${{ matrix.os }}
 
@@ -56,26 +78,14 @@ jobs:
     - name: Test with dotnet
       run: dotnet test OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }}
 
-
     - name: Publish with dotnet
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime ${{ matrix.target }} --no-self-contained -p:PublishSingleFile=true --output ./OpenDirectoryDownloader-${{ matrix.target }}
+      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime ${{ matrix.target }} ${{ matrix.build_args }} --p:PublishSingleFile=true --output ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
 
     - name: Zipping
       uses: papeloto/action-zip@v1
       with:
-        files: ./OpenDirectoryDownloader-${{ matrix.target }}
-        dest: OpenDirectoryDownloader-${{ matrix.target }}.zip
-
-
-    - name: Publish with dotnet (self-contained)
-      run: dotnet publish OpenDirectoryDownloader --configuration Release -p:Version=${{ steps.get_version.outputs.VERSION }} --framework net5.0 --runtime ${{ matrix.target }} --self-contained=true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:IncludeNativeLibrariesForSelfExtract=true --output ./OpenDirectoryDownloader-${{ matrix.target }}-self-contained
-
-    - name: Zipping (self-contained)
-      uses: papeloto/action-zip@v1
-      with:
-        files: ./OpenDirectoryDownloader-${{ matrix.target }}-self-contained
-        dest: OpenDirectoryDownloader-${{ matrix.target }}-self-contained.zip
-
+        files: ./OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}
+        dest: OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip
 
     - name: Upload artifact for docker job (linux only)
       if: matrix.kind == 'linux'
@@ -83,7 +93,7 @@ jobs:
       with:
         name: linux-x64
         path: |
-          OpenDirectoryDownloader-${{ matrix.target }}.zip
+          OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip
           Dockerfile
 
     - name: Create release
@@ -98,9 +108,7 @@ jobs:
         prerelease: false
         body: ${{ github.event.head_commit.message }}
         files: |
-          OpenDirectoryDownloader-${{ matrix.target }}.zip
-          OpenDirectoryDownloader-${{ matrix.target }}-self-contained.zip
-
+          OpenDirectoryDownloader-${{ matrix.target }}${{ matrix.suffix }}.zip
 
 
   docker:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: OpenDirectoryDownloader ${{ github.ref }}
+        name: OpenDirectoryDownloader ${{ github.ref }}
         draft: false
         prerelease: false
         body: ${{ github.event.head_commit.message }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,26 +97,9 @@ jobs:
         draft: false
         prerelease: false
         body: ${{ github.event.head_commit.message }}
-        
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-${{ matrix.target }}.zip
-        asset_name: OpenDirectoryDownloader-${{ matrix.target }}.zip
-        asset_content_type: application/zip
-        
-    - name: Upload Release Asset (self-contained)
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./OpenDirectoryDownloader-${{ matrix.target }}-self-contained.zip
-        asset_name: OpenDirectoryDownloader-${{ matrix.target }}-self-contained.zip
-        asset_content_type: application/zip
+        files: |
+          OpenDirectoryDownloader-${{ matrix.target }}.zip
+          OpenDirectoryDownloader-${{ matrix.target }}-self-contained.zip
 
 
 


### PR DESCRIPTION
This PR reworks the github actions workflow into matrix form, and fixes #52.

Notable changes:

- All builds run in parallel thanks to a matrix
- Linux based builds now run `chmod +x`
- Zipping is done using 7z (#52)
- All zips are uploaded into an intermediate artifact
- A release jobs pulls them, and uploads it to a new release
- Release creation now uses `softprops/action-gh-release`, because `actions/upload-release-asset` doesn't support wildcard uploading
- The docker job has not been changed