### PR TITLE
added flag for copy to clipboard after scan (-c)

### DIFF
--- a/OpenDirectoryDownloader/CommandLineOptions.cs
+++ b/OpenDirectoryDownloader/CommandLineOptions.cs
@@ -16,6 +16,9 @@ namespace OpenDirectoryDownloader
         [Option('q', "quit", Required = false, Default = false, HelpText = "Do not wait after scanning")]
         public bool Quit { get; set; }
 
+        [Option('c', "clipboard", Required = false, Default = false, HelpText = "Copy Reddit stats after scanning")]
+        public bool Clipboard { get; set; }
+
         [Option('j', "json", Required = false, Default = false, HelpText = "Save JSON file")]
         public bool Json { get; set; }
 

--- a/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
+++ b/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
@@ -482,7 +482,8 @@ namespace OpenDirectoryDownloader
 
                     Program.SetConsoleTitle($"✔ {Program.ConsoleTitle}");
                     
-                    Boolean clipboardSuccess = false;
+                    bool clipboardSuccess = false;
+
                     if (OpenDirectoryIndexerSettings.CommandLineOptions.Clipboard)
                     {
                         try

--- a/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
+++ b/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
@@ -19,6 +19,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using TextCopy;
 
 namespace OpenDirectoryDownloader
 {
@@ -480,14 +481,29 @@ namespace OpenDirectoryDownloader
                     Console.WriteLine("Finished indexing!");
 
                     Program.SetConsoleTitle($"✔ {Program.ConsoleTitle}");
-
+                    
+                    Boolean clipboardSuccess = false;
+                    if (OpenDirectoryIndexerSettings.CommandLineOptions.Clipboard)
+                    {
+                        try
+                        {
+                            new Clipboard().SetText(Statistics.GetSessionStats(OpenDirectoryIndexer.Session, includeExtensions: true, onlyRedditStats: true));
+                            Console.WriteLine("Copied Reddit stats to clipboard!");
+                            clipboardSuccess = true;
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error($"Error copying stats to clipboard: {ex.Message}");
+                        }
+                    }
+                    
                     if (OpenDirectoryIndexerSettings.CommandLineOptions.Quit)
                     {
                         Command.KillApplication();
                     }
                     else
                     {
-                        Console.WriteLine("Press ESC to exit! Or C to copy to clipboard and quit!");
+                        Console.WriteLine(clipboardSuccess ? "Press ESC to exit!" : "Press ESC to exit! Or C to copy to clipboard and quit!");
                     }
                 }
                 catch (Exception ex)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Command line parameters:
 | `-t` | `--threads` | Number of threads (default 5) |
 | `-o` | `--timeout` | Number of seconds for timeout |
 | `-q` | `--quit` | Quit after scanning (No "Press a key") |
+| `-c` | `--clipboard` | Automatically copy the Reddits stats once the scan is done |
 | `-j` | `--json` | Save JSON file |
 | `-f` | `--no-urls` | Do not save URLs file |
 | `-r` | `--no-reddit` | Do not show Reddit stats markdown |
@@ -56,7 +57,7 @@ If you want to learn more or contribute, see the following paragraphs!
 
 ### Copying on Linux
 
-When you want to copy (`C` key) the stats at the end on Linux you need to have xclip installed.
+When you want to copy (`C` key or `-c` flag) the stats at the end on Linux you need to have xclip installed.
 
 ## Docker
 


### PR DESCRIPTION
- flag name is `-c` or `--clipboard`
- copies the reddit stats to the clipboard once the indexer is finished
- combined with `-q`, this closes #68

I also added some logic to detect if the clipboard copy worked and change the last `WriteLine()` accordingly.

Also: There are two failing test, but they were present right after forking, so I guess they aren't related...

Hope this is what you had in mind 😇