### PR TITLE
Added option to skip HEAD requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,12 @@ FodyWeavers.xsd
 /OpenDirectoryDownloader.GoogleDrive/OpenDirectoryDownloader.GoogleDrive.json
 # Local todo file
 /TODO.txt
+
+# VS Code workspace settings
+.vscode
+
+# Windows build folder
+OpenDirectoryDownloader-win-x64/
+
+# Scans folder
+OpenDirectoryDownloader/Scans/

--- a/OpenDirectoryDownloader.Shared/Models/WebDirectory.cs
+++ b/OpenDirectoryDownloader.Shared/Models/WebDirectory.cs
@@ -29,7 +29,7 @@ namespace OpenDirectoryDownloader.Shared.Models
         public bool Finished { get; set; }
 
         [JsonIgnore]
-        public bool ParsedSuccesfully { get; set; }
+        public bool ParsedSuccessfully { get; set; }
 
         public ConcurrentList<WebDirectory> Subdirectories { get; set; } = new ConcurrentList<WebDirectory>();
 

--- a/OpenDirectoryDownloader.Tests/DirectoryParser000_025Tests.cs
+++ b/OpenDirectoryDownloader.Tests/DirectoryParser000_025Tests.cs
@@ -133,7 +133,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Equal("Crystal Maps", webDirectory.Subdirectories[0].Name);
             Assert.Single(webDirectory.Files);
             Assert.Equal("Pokemon Crystal.sg1.SGM", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Equal("Nintendo DS", webDirectory.Subdirectories[0].Name);
             Assert.Equal(7, webDirectory.Files.Count);
             Assert.Equal("Pokemon Dash.zip", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>

--- a/OpenDirectoryDownloader.Tests/DirectoryParser026_050Tests.cs
+++ b/OpenDirectoryDownloader.Tests/DirectoryParser026_050Tests.cs
@@ -693,7 +693,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Equal("AGA 6-4 Ceramic Hob Pre Oven Efficiency", webDirectory.Subdirectories[0].Name);
             Assert.Equal(8, webDirectory.Files.Count);
             Assert.Equal("Aga Elect 13amp 2 and 4 oven manual 03-07 EINS 513935 (UK).pdf", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -708,7 +708,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Empty(webDirectory.Subdirectories);
             Assert.Equal(2, webDirectory.Files.Count);
             Assert.Equal("Aga Six Four electric manual11-09 EINS 513129.pdf", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>

--- a/OpenDirectoryDownloader.Tests/DirectoryParser051_075Tests.cs
+++ b/OpenDirectoryDownloader.Tests/DirectoryParser051_075Tests.cs
@@ -234,7 +234,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Equal("Old-Calculator-RPGs-Headquarter-Archive", webDirectory.Subdirectories[0].Name);
             Assert.Single(webDirectory.Files);
             Assert.Equal("master.index", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -249,7 +249,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Empty(webDirectory.Subdirectories);
             Assert.Equal(6, webDirectory.Files.Count);
             Assert.Equal("aronstyle.zip", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -400,7 +400,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Equal("Coco 2017 HD-TS X264 HQ-CPG", webDirectory.Subdirectories[0].Name);
             Assert.Equal(15, webDirectory.Files.Count);
             Assert.Equal("Aquaman 2018 720p.mp4", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -415,7 +415,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Empty(webDirectory.Subdirectories);
             Assert.Equal(12, webDirectory.Files.Count);
             Assert.Equal("Ant.Man.2015.720p.HDRip.x264.AAC-ETRG.mp4", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -708,8 +708,8 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Equal("ALS Scan - Franziska Facella & Sara Jaymes - Clutch Hitter BTS (12-10-18).mp4", webDirectory.Files[0].FileName);
             Assert.Equal(335910500, webDirectory.Files[0].FileSize);
 
-            // This directory listing contains negative file sizes, which will result in "-1"
-            Assert.Contains(webDirectory.Files, f => f.FileSize == -1);
+            // This directory listing contains negative file sizes, which will result in "0"
+            Assert.Contains(webDirectory.Files, f => f.FileSize == 0);
         }
 
         /// <summary>

--- a/OpenDirectoryDownloader.Tests/DirectoryParser076_100Tests.cs
+++ b/OpenDirectoryDownloader.Tests/DirectoryParser076_100Tests.cs
@@ -66,7 +66,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Empty(webDirectory.Subdirectories);
             Assert.Equal(487, webDirectory.Files.Count);
             Assert.Equal("Q836 (Side A).mp3", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Empty(webDirectory.Subdirectories);
             Assert.Equal(18, webDirectory.Files.Count);
             Assert.Equal("bootstrap.cerulean.min.css", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -399,7 +399,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Equal("视频", webDirectory.Subdirectories[0].Name);
             Assert.Equal(32, webDirectory.Files.Count);
             Assert.Equal("␠(1).jpg", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -429,7 +429,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Equal("Amiga", webDirectory.Subdirectories[0].Name);
             Assert.Single(webDirectory.Files);
             Assert.Equal("[All Systems-Complete].torrent", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -444,7 +444,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Empty(webDirectory.Subdirectories);
             Assert.Equal(8, webDirectory.Files.Count);
             Assert.Equal("3D Boxing.zip", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         // TODO:

--- a/OpenDirectoryDownloader.Tests/DirectoryParser101_125Tests.cs
+++ b/OpenDirectoryDownloader.Tests/DirectoryParser101_125Tests.cs
@@ -53,7 +53,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Equal("@eaDir", webDirectory.Subdirectories[0].Name);
             Assert.Equal(57, webDirectory.Files.Count);
             Assert.Equal("2020 Force Works 002 (2020) (Digital) (Zone-Empire).cbr", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Empty(webDirectory.Subdirectories);
             Assert.Equal(24, webDirectory.Files.Count);
             Assert.Equal("Amazon.cbr", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>
@@ -324,7 +324,7 @@ namespace OpenDirectoryDownloader.Tests
             Assert.Equal("2009-addition", webDirectory.Subdirectories[0].Name);
             Assert.Equal(5, webDirectory.Files.Count);
             Assert.Equal("change_log.txt", webDirectory.Files[0].FileName);
-            Assert.Equal(-1, webDirectory.Files[0].FileSize);
+            Assert.Equal(0, webDirectory.Files[0].FileSize);
         }
 
         /// <summary>

--- a/OpenDirectoryDownloader.Tests/Samples/DirectoryListing115a.html.dat
+++ b/OpenDirectoryDownloader.Tests/Samples/DirectoryListing115a.html.dat
@@ -1,0 +1,156 @@
+﻿<html>
+<head>
+<title>/ のディレクトリの一覧</title>
+<STYLE><!--H1 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:22px;} H2 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:16px;} H3 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:14px;} BODY {font-family:Tahoma,Arial,sans-serif;color:black;background-color:white;} B {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;} P {font-family:Tahoma,Arial,sans-serif;background:white;color:black;font-size:12px;}A {color : black;}A.name {color : black;}HR {color : #525D76;}--></STYLE> </head>
+<body><h1>/ のディレクトリの一覧</h1><HR size="1" noshade="noshade"><table width="100%" cellspacing="0" cellpadding="5" align="center">
+<tr>
+<td align="left"><font size="+1"><strong>ファイル名</strong></font></td>
+<td align="center"><font size="+1"><strong>サイズ</strong></font></td>
+<td align="right"><font size="+1"><strong>最終更新</strong></font></td>
+</tr><tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/Thumbs.db"><tt>Thumbs.db</tt></a></td>
+<td align="right"><tt>25.4 kb</tt></td>
+<td align="right"><tt>Mon, 13 Mar 2017 07:35:36 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/alibar.jsp"><tt>alibar.jsp</tt></a></td>
+<td align="right"><tt>23.9 kb</tt></td>
+<td align="right"><tt>Fri, 26 Feb 2016 11:37:05 GMT</tt></td>
+</tr>
+<tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/alipay.jsp"><tt>alipay.jsp</tt></a></td>
+<td align="right"><tt>18.1 kb</tt></td>
+<td align="right"><tt>Wed, 13 Apr 2016 10:05:27 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/basms/"><tt>basms/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:44:08 GMT</tt></td>
+</tr>
+<tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/cb.apk"><tt>cb.apk</tt></a></td>
+<td align="right"><tt>202.5 kb</tt></td>
+<td align="right"><tt>Sat, 30 May 2020 07:51:12 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/emenu/"><tt>emenu/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:46:17 GMT</tt></td>
+</tr>
+<tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/finance/"><tt>finance/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:46:21 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/goodsjpg/"><tt>goodsjpg/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:46:29 GMT</tt></td>
+</tr>
+<tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/hide.apk"><tt>hide.apk</tt></a></td>
+<td align="right"><tt>290.1 kb</tt></td>
+<td align="right"><tt>Wed, 19 Mar 2014 01:33:40 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/kalaok/"><tt>kalaok/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:46:31 GMT</tt></td>
+</tr>
+<tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/memshare/"><tt>memshare/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:46:51 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/pay.htm"><tt>pay.htm</tt></a></td>
+<td align="right"><tt>1.5 kb</tt></td>
+<td align="right"><tt>Wed, 24 Feb 2016 03:12:33 GMT</tt></td>
+</tr>
+<tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/qr.jpg"><tt>qr.jpg</tt></a></td>
+<td align="right"><tt>18.9 kb</tt></td>
+<td align="right"><tt>Mon, 19 Sep 2016 00:44:50 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/shutdown.jsp"><tt>shutdown.jsp</tt></a></td>
+<td align="right"><tt>0.8 kb</tt></td>
+<td align="right"><tt>Mon, 26 Sep 2016 07:22:28 GMT</tt></td>
+</tr>
+<tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/skin/"><tt>skin/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:46:53 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/t_goods.xls"><tt>t_goods.xls</tt></a></td>
+<td align="right"><tt>2.3 kb</tt></td>
+<td align="right"><tt>Mon, 09 Nov 2020 17:19:01 GMT</tt></td>
+</tr>
+<tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/t_sellgathering.xls"><tt>t_sellgathering.xls</tt></a></td>
+<td align="right"><tt>1.5 kb</tt></td>
+<td align="right"><tt>Thu, 16 Jan 2020 05:03:09 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/wcms/"><tt>wcms/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:46:53 GMT</tt></td>
+</tr>
+<tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/webauto/"><tt>webauto/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:48:40 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/webbean/"><tt>webbean/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:48:40 GMT</tt></td>
+</tr>
+<tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/webshare/"><tt>webshare/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:49:19 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/wity/"><tt>wity/</tt></a></td>
+<td align="right"><tt>&nbsp;</tt></td>
+<td align="right"><tt>Thu, 04 Feb 2021 13:49:20 GMT</tt></td>
+</tr>
+<tr>
+<td align="left">&nbsp;&nbsp;
+<a href="/wx.jsp"><tt>wx.jsp</tt></a></td>
+<td align="right"><tt>19.6 kb</tt></td>
+<td align="right"><tt>Wed, 03 Feb 2016 00:46:32 GMT</tt></td>
+</tr>
+<tr bgcolor="#eeeeee">
+<td align="left">&nbsp;&nbsp;
+<a href="/wxpay.jsp"><tt>wxpay.jsp</tt></a></td>
+<td align="right"><tt>3.5 kb</tt></td>
+<td align="right"><tt>Mon, 12 Sep 2016 09:15:21 GMT</tt></td>
+</tr>
+</table>
+<HR size="1" noshade="noshade"><h3>Apache Tomcat/6.0.18</h3></body>
+</html>

--- a/OpenDirectoryDownloader/CommandLineOptions.cs
+++ b/OpenDirectoryDownloader/CommandLineOptions.cs
@@ -49,6 +49,9 @@ namespace OpenDirectoryDownloader
         [Option("output-file", Required = false, Default = null, HelpText = "Save output files to specific base filename")]
         public string OutputFile { get; set; }
 
+        [Option("fast-scan", Required = false, Default = false, HelpText = "Only perform actions that are fast, so no HEAD requests, etc. Might result in missing file sizes")]
+        public bool FastScan { get; set; }
+
         // TODO: Future use
         //[Option('d', "download", Required = false, HelpText = "Downloads the contents (after indexing is finished)")]
         //public bool Download { get; set; }

--- a/OpenDirectoryDownloader/Constants.cs
+++ b/OpenDirectoryDownloader/Constants.cs
@@ -8,7 +8,7 @@
         public const string Parameters_Password = "PASSWORD";
         public const string Parameters_GdIndex_RootId = "GdIndex_RootId";
         public const string Parameters_FtpEncryptionMode = "FtpEncryptionMode";
-        public const long NoFileSize = -1;
+        public const long NoFileSize = 0;
         public const string Root = "ROOT";
         public const string Ftp_Max_Connections = "MAX_CONNECTIONS";
 

--- a/OpenDirectoryDownloader/DirectoryParser.cs
+++ b/OpenDirectoryDownloader/DirectoryParser.cs
@@ -158,7 +158,7 @@ namespace OpenDirectoryDownloader
 
                 WebDirectory parsedJavaScriptDrawn = await ParseJavaScriptDrawn(baseUrl, parsedWebDirectory, html);
 
-                if (parsedJavaScriptDrawn.ParsedSuccesfully && (parsedJavaScriptDrawn.Files.Any() || parsedJavaScriptDrawn.Subdirectories.Any()))
+                if (parsedJavaScriptDrawn.ParsedSuccessfully && (parsedJavaScriptDrawn.Files.Any() || parsedJavaScriptDrawn.Subdirectories.Any()))
                 {
                     return parsedJavaScriptDrawn;
                 }
@@ -188,7 +188,7 @@ namespace OpenDirectoryDownloader
                 {
                     WebDirectory result = ParseListItemsDirectoryListing(baseUrl, parsedWebDirectory, listItems);
 
-                    if (result.ParsedSuccesfully || result.Error)
+                    if (result.ParsedSuccessfully || result.Error)
                     {
                         return result;
                     }
@@ -200,7 +200,7 @@ namespace OpenDirectoryDownloader
                 {
                     WebDirectory result = ParseListItemsDirectoryListing(baseUrl, parsedWebDirectory, listItems);
 
-                    if (result.ParsedSuccesfully || result.Error)
+                    if (result.ParsedSuccessfully || result.Error)
                     {
                         return result;
                     }
@@ -248,7 +248,7 @@ namespace OpenDirectoryDownloader
 
             if (matchCollectionDirectories.Any() || matchCollectionFiles.Any())
             {
-                parsedWebDirectory.ParsedSuccesfully = true;
+                parsedWebDirectory.ParsedSuccessfully = true;
 
                 foreach (Match directory in matchCollectionDirectories)
                 {
@@ -313,7 +313,7 @@ namespace OpenDirectoryDownloader
                         parsedWebDirectory.Name = newWebDirectory.Name;
                         parsedWebDirectory.Subdirectories = newWebDirectory.Subdirectories;
                         parsedWebDirectory.Url = newWebDirectory.Url;
-                        parsedWebDirectory.ParsedSuccesfully = true;
+                        parsedWebDirectory.ParsedSuccessfully = true;
                         parsedWebDirectory.Parser = "DirectoryListingModel01";
                     }
                 }
@@ -718,7 +718,7 @@ namespace OpenDirectoryDownloader
                 }
                 else
                 {
-                    webDirectoryCopy.ParsedSuccesfully = true;
+                    webDirectoryCopy.ParsedSuccessfully = true;
 
                     foreach (IElement tableRow in table.QuerySelectorAll("tbody tr"))
                     {
@@ -857,7 +857,7 @@ namespace OpenDirectoryDownloader
 
             if (!hasSeperateDirectoryAndFilesTables)
             {
-                parsedWebDirectory = results.Where(r => (r.ParsedSuccesfully || r.Error) && (r.Files.Count > 0 || r.Subdirectories.Count > 0)).OrderByDescending(r => r.HeaderCount).ThenByDescending(r => r.TotalDirectoriesIncludingUnfinished + r.TotalFiles).FirstOrDefault() ?? parsedWebDirectory;
+                parsedWebDirectory = results.Where(r => (r.ParsedSuccessfully || r.Error) && (r.Files.Count > 0 || r.Subdirectories.Count > 0)).OrderByDescending(r => r.HeaderCount).ThenByDescending(r => r.TotalDirectoriesIncludingUnfinished + r.TotalFiles).FirstOrDefault() ?? parsedWebDirectory;
             }
             else
             {
@@ -1684,7 +1684,7 @@ namespace OpenDirectoryDownloader
                         return;
                     }
 
-                    parsedWebDirectory.ParsedSuccesfully = true;
+                    parsedWebDirectory.ParsedSuccessfully = true;
 
                     bool directoryListAsp = Path.GetFileName(fullUrl) == "DirectoryList.asp" || fullUrl.Contains("DirectoryList.asp");
                     bool dirParam = urlEncodingParser["dir"] != null || urlEncodingParser["path"] != null;

--- a/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
+++ b/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
@@ -1017,7 +1017,7 @@ namespace OpenDirectoryDownloader
                 return (uri.Scheme != Constants.UriScheme.Https && uri.Scheme != Constants.UriScheme.Http && uri.Scheme != Constants.UriScheme.Ftp && uri.Scheme != Constants.UriScheme.Ftps) || uri.Host != Session.Root.Uri.Host || !SameHostAndDirectory(uri, Session.Root.Uri);
             }).ToList().ForEach(wd => webDirectory.Files.Remove(wd));
 
-            foreach (WebFile webFile in webDirectory.Files.Where(f => f.FileSize == Constants.NoFileSize || OpenDirectoryIndexerSettings.CommandLineOptions.ExactFileSizes))
+            foreach (WebFile webFile in webDirectory.Files.Where(f => (f.FileSize == Constants.NoFileSize && !OpenDirectoryIndexerSettings.CommandLineOptions.FastScan) || OpenDirectoryIndexerSettings.CommandLineOptions.ExactFileSizes))
             {
                 WebFilesFileSizeQueue.Enqueue(webFile);
             }

--- a/OpenDirectoryDownloader/Site/BlitzfilesTech/BlitzfilesTechParser.cs
+++ b/OpenDirectoryDownloader/Site/BlitzfilesTech/BlitzfilesTechParser.cs
@@ -100,7 +100,7 @@ namespace OpenDirectoryDownloader.Site.BlitzfilesTech
 
                     HttpResponseMessage httpResponseMessage = await httpClient.GetAsync(GetFolderUrl(driveHash, entryHash, pageIndex));
 
-                    webDirectory.ParsedSuccesfully = httpResponseMessage.IsSuccessStatusCode;
+                    webDirectory.ParsedSuccessfully = httpResponseMessage.IsSuccessStatusCode;
                     httpResponseMessage.EnsureSuccessStatusCode();
 
                     string responseJson = await httpResponseMessage.Content.ReadAsStringAsync();

--- a/OpenDirectoryDownloader/Site/GoIndex/BhadooIndexParser.cs
+++ b/OpenDirectoryDownloader/Site/GoIndex/BhadooIndexParser.cs
@@ -116,14 +116,14 @@ namespace OpenDirectoryDownloader.Site.GoIndex.Bhadoo
                     }
                     else
                     {
-                        webDirectory.ParsedSuccesfully = httpResponseMessage.IsSuccessStatusCode;
+                        webDirectory.ParsedSuccessfully = httpResponseMessage.IsSuccessStatusCode;
                         httpResponseMessage.EnsureSuccessStatusCode();
 
                         string responseJson = await httpResponseMessage.Content.ReadAsStringAsync();
 
                         BhadooIndexResponse indexResponse = BhadooIndexResponse.FromJson(responseJson);
 
-                        webDirectory.ParsedSuccesfully = indexResponse.Data.Error == null;
+                        webDirectory.ParsedSuccessfully = indexResponse.Data.Error == null;
 
                         if (indexResponse.Data.Error?.Message == "Rate Limit Exceeded")
                         {

--- a/OpenDirectoryDownloader/Site/GoIndex/GdIndexParser.cs
+++ b/OpenDirectoryDownloader/Site/GoIndex/GdIndexParser.cs
@@ -145,14 +145,14 @@ namespace OpenDirectoryDownloader.Site.GoIndex.GdIndex
 
                 HttpResponseMessage httpResponseMessage = await httpClient.PostAsync($"{OpenDirectoryIndexer.Session.Root.Url}{Uri.EscapeDataString(webDirectory.Url.Replace(OpenDirectoryIndexer.Session.Root.Url, string.Empty).TrimEnd('/'))}/?rootId={OpenDirectoryIndexer.Session.Parameters[Constants.Parameters_GdIndex_RootId]}", null);
 
-                webDirectory.ParsedSuccesfully = httpResponseMessage.IsSuccessStatusCode;
+                webDirectory.ParsedSuccessfully = httpResponseMessage.IsSuccessStatusCode;
                 httpResponseMessage.EnsureSuccessStatusCode();
 
                 string responseJson = await httpResponseMessage.Content.ReadAsStringAsync();
 
                 GdIndexResponse indexResponse = GdIndexResponse.FromJson(responseJson);
 
-                webDirectory.ParsedSuccesfully = indexResponse != null;
+                webDirectory.ParsedSuccessfully = indexResponse != null;
 
                 foreach (File file in indexResponse.Files)
                 {

--- a/OpenDirectoryDownloader/Site/GoIndex/Go2IndexParser.cs
+++ b/OpenDirectoryDownloader/Site/GoIndex/Go2IndexParser.cs
@@ -152,14 +152,14 @@ namespace OpenDirectoryDownloader.Site.GoIndex.Go2Index
                             { "q", "" }
                         })));
 
-                        webDirectory.ParsedSuccesfully = httpResponseMessage.IsSuccessStatusCode;
+                        webDirectory.ParsedSuccessfully = httpResponseMessage.IsSuccessStatusCode;
                         httpResponseMessage.EnsureSuccessStatusCode();
 
                         string responseJson = await httpResponseMessage.Content.ReadAsStringAsync();
 
                         Go2IndexResponse indexResponse = Go2IndexResponse.FromJson(responseJson);
 
-                        webDirectory.ParsedSuccesfully = indexResponse.Error == null;
+                        webDirectory.ParsedSuccessfully = indexResponse.Error == null;
 
                         if (indexResponse.Error != null)
                         {

--- a/OpenDirectoryDownloader/Site/GoIndex/GoIndexParser.cs
+++ b/OpenDirectoryDownloader/Site/GoIndex/GoIndexParser.cs
@@ -131,14 +131,14 @@ namespace OpenDirectoryDownloader.Site.GoIndex
                     { "password", OpenDirectoryIndexer.Session.Parameters[Constants.Parameters_Password] }
                 })));
 
-                webDirectory.ParsedSuccesfully = httpResponseMessage.IsSuccessStatusCode;
+                webDirectory.ParsedSuccessfully = httpResponseMessage.IsSuccessStatusCode;
                 httpResponseMessage.EnsureSuccessStatusCode();
 
                 string responseJson = await httpResponseMessage.Content.ReadAsStringAsync();
 
                 GoIndexResponse indexResponse = GoIndexResponse.FromJson(responseJson);
 
-                webDirectory.ParsedSuccesfully = indexResponse.Error == null;
+                webDirectory.ParsedSuccessfully = indexResponse.Error == null;
 
                 if (indexResponse.Error != null)
                 {

--- a/OpenDirectoryDownloader/Statistics.cs
+++ b/OpenDirectoryDownloader/Statistics.cs
@@ -62,10 +62,10 @@ namespace OpenDirectoryDownloader
 
             foreach (KeyValuePair<int, int> statusCode in session.HttpStatusCodes.OrderBy(statusCode => statusCode.Key))
             {
-                stringBuilder.AppendLine($"{statusCode.Key}: {statusCode.Value}");
+                stringBuilder.AppendLine($"{statusCode.Key}: {statusCode.Value}"); 
             }
 
-            stringBuilder.AppendLine($"Total files: {Library.FormatWithThousands(session.Root.TotalFiles)}, Total estimated size: {FileSizeHelper.ToHumanReadable(session.Root.TotalFileSize)}");
+            stringBuilder.AppendLine($"Total files: {Library.FormatWithThousands(session.Root.TotalFiles)}, Total estimated size: { (session.Root.TotalFileSize > 0 ? FileSizeHelper.ToHumanReadable(session.Root.TotalFileSize) : "n/a") }");
             stringBuilder.AppendLine($"Total directories: {Library.FormatWithThousands(session.Root.TotalDirectories + 1)}");
             stringBuilder.AppendLine($"Total HTTP requests: {Library.FormatWithThousands(session.TotalHttpRequests)}, Total HTTP traffic: {FileSizeHelper.ToHumanReadable(session.TotalHttpTraffic)}");
 

--- a/OpenDirectoryDownloader/Statistics.cs
+++ b/OpenDirectoryDownloader/Statistics.cs
@@ -91,12 +91,18 @@ namespace OpenDirectoryDownloader
             {
                 stringBuilder.AppendLine("|**Extension (Top 5)**|**Files**|**Size**|");
 
-                foreach (KeyValuePair<string, ExtensionStats> extensionStat in extensionsStats.OrderByDescending(e => e.Value.FileSize).Take(5))
+                foreach (KeyValuePair<string, ExtensionStats> extensionStat in extensionsStats.OrderByDescending(e => {
+                    if (e.Value.FileSize > 0) {
+                        return e.Value.FileSize;
+                    } else {
+                        return e.Value.Count;
+                    }
+                }).Take(5))
                 {
-                    stringBuilder.AppendLine($"|{extensionStat.Key}|{Library.FormatWithThousands(extensionStat.Value.Count)}|{FileSizeHelper.ToHumanReadable(extensionStat.Value.FileSize)}|");
+                    stringBuilder.AppendLine($"|{extensionStat.Key}|{Library.FormatWithThousands(extensionStat.Value.Count)}|{ (extensionStat.Value.FileSize > 0 ? FileSizeHelper.ToHumanReadable(extensionStat.Value.FileSize) : "n/a")}|");
                 }
 
-                stringBuilder.AppendLine($"|**Dirs:** {Library.FormatWithThousands(session.Root.TotalDirectories + 1)} **Ext:** {Library.FormatWithThousands(extensionsStats.Count)}|**Total:** {Library.FormatWithThousands(session.TotalFiles)}|**Total:** {FileSizeHelper.ToHumanReadable(session.TotalFileSizeEstimated)}|");
+                stringBuilder.AppendLine($"|**Dirs:** {Library.FormatWithThousands(session.Root.TotalDirectories + 1)} **Ext:** {Library.FormatWithThousands(extensionsStats.Count)}|**Total:** {Library.FormatWithThousands(session.TotalFiles)}|**Total:** { (session.TotalFileSizeEstimated > 0 ? FileSizeHelper.ToHumanReadable(session.TotalFileSizeEstimated) : "n/a") }|");
             }
 
             stringBuilder.AppendLine($"|**Date (UTC):** {session.Started.ToString(Constants.DateTimeFormat)}|**Time:** {TimeSpan.FromSeconds((int)((session.Finished == DateTimeOffset.MinValue ? DateTimeOffset.UtcNow : session.Finished) - session.Started).TotalSeconds)}|{(session.SpeedtestResult != null ? $"**Speed:** {(session.SpeedtestResult.DownloadedBytes > 0 ? $"{session.SpeedtestResult.MaxMBsPerSecond:F1} MB/s ({session.SpeedtestResult.MaxMBsPerSecond * 8:F0} mbit)" : "Failed")}" : string.Empty)}|");


### PR DESCRIPTION
Added a new command line flag called `--fast-scan`. 

The flag will cause ODD to not use HEAD request to determine file sizes, even if there's no other way to get the file size (becuase the server didn't include them in the HTML reponse).  
This behavior can be overwritten by using the `-e` flag.  

Also added appropriate error handling for missing file sizes:

- if file sizes are missing, statistics will report them as "n/a" and sort the top 5 extensions by count instead of size
- the total size will also be reported as "n/a"

However, there is an edge case:  
If the server doesn't report file sizes for some files, but does so for others, things might go haywire.  
I will try to cover this edge case in the coming days.

There also two failing tests that I don't really know how to fix, because I haven't had the time to properly read the code, hence the draft.

What do you think of my general approach? Is this okay?