### PR TITLE
always use a proper markdown URL in stats

### DIFF
--- a/src/OpenDirectoryDownloader/Statistics.cs
+++ b/src/OpenDirectoryDownloader/Statistics.cs
@@ -81,7 +81,7 @@ namespace OpenDirectoryDownloader
 
             if (session.Root.Url.Length < 40)
             {
-                stringBuilder.AppendLine($"|**Url:** {session.Root.Url}||{uploadedUrlsText}|");
+                stringBuilder.AppendLine($"|**Url:** [{session.Root.Url}]({session.Root.Url})||{uploadedUrlsText}|");
             }
             else
             {


### PR DESCRIPTION
- added []() syntax for the Url section in the stats, even if URL is short
- this fixes #97