### PR TITLE
Better Speedtest Results

### DIFF
--- a/src/OpenDirectoryDownloader.Shared/Models/SpeedtestResult.cs
+++ b/src/OpenDirectoryDownloader.Shared/Models/SpeedtestResult.cs
@@ -4,9 +4,14 @@
     {
         public long DownloadedBytes { get; set; }
         public double DownloadedMBs => DownloadedBytes / 1024d / 1024d;
+        public double DownloadedKBs => DownloadedBytes / 1024d;
         public long ElapsedMilliseconds { get; set; }
         public double MBsPerSecond => DownloadedMBs / (ElapsedMilliseconds / 1000d);
         public double MbitsPerSecond => DownloadedMBs / (ElapsedMilliseconds / 1000d) * 8;
+        public double KBsPerSecond => DownloadedKBs / (ElapsedMilliseconds / 1000d);
+        public double KbitsPerSecond => DownloadedKBs / (ElapsedMilliseconds / 1000d) * 8;
         public double MaxMBsPerSecond { get; set; }
+        public double MaxKBsPerSecond { get; set; }
+        public long MaxBytesPerSecond { get; set; }
     }
 }

--- a/src/OpenDirectoryDownloader/Helpers/FileSizeHelper.cs
+++ b/src/OpenDirectoryDownloader/Helpers/FileSizeHelper.cs
@@ -118,8 +118,9 @@ namespace OpenDirectoryDownloader.Helpers
         }
 
         private static readonly string[] sizeSuffixes = { "B", "kiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB" };
+        private static readonly string[] sizeSuffixesBit = { "b", "kib", "Mib", "Gib", "Tib", "Pib", "Eib", "Zib", "Yib" };
 
-        public static string ToHumanReadable(long size)
+        public static string ToHumanReadable(long size, bool useBits = false)
         {
             Debug.Assert(sizeSuffixes.Length > 0);
 
@@ -138,7 +139,8 @@ namespace OpenDirectoryDownloader.Helpers
                 : intPower;
             double normSize = absSize / Math.Pow(1024, iUnit);
 
-            return string.Format(formatTemplate, size < 0 ? "-" : null, normSize, sizeSuffixes[iUnit]);
+            return string.Format(formatTemplate, size < 0 ? "-" : null, normSize, (useBits ? sizeSuffixesBit : sizeSuffixes)[iUnit]);
         }
+
     }
 }

--- a/src/OpenDirectoryDownloader/Statistics.cs
+++ b/src/OpenDirectoryDownloader/Statistics.cs
@@ -110,7 +110,7 @@ namespace OpenDirectoryDownloader
 
             // stringBuilder.AppendLine($"|**Date (UTC):** {session.Started.ToString(Constants.DateTimeFormat)}|**Time:** {TimeSpan.FromSeconds((int)((session.Finished == DateTimeOffset.MinValue ? DateTimeOffset.UtcNow : session.Finished) - session.Started).TotalSeconds)}|{(session.SpeedtestResult != null ? $"**Speed:** {(session.SpeedtestResult.DownloadedBytes > 0 ? $"{session.SpeedtestResult.MaxMBsPerSecond:F1} MB/s ({session.SpeedtestResult.MaxMBsPerSecond * 8:F0} mbit)" : "Failed")}" : string.Empty)}|");
 
-            stringBuilder.AppendLine($"|**Date (UTC):** {session.Started.ToString(Constants.DateTimeFormat)}|**Time:** {TimeSpan.FromSeconds((int)((session.Finished == DateTimeOffset.MinValue ? DateTimeOffset.UtcNow : session.Finished) - session.Started).TotalSeconds)}|{(session.SpeedtestResult != null ? $"**Speed:** {(session.SpeedtestResult.DownloadedBytes > 0 ? $"{FileSizeHelper.ToHumanReadable(session.SpeedtestResult.MaxBytesPerSecond):F1}/s ({FileSizeHelper.ToHumanReadable(session.SpeedtestResult.MaxBytesPerSecond * 8, true):F0}/s)" : "Failed")}" : string.Empty)}|");
+            stringBuilder.AppendLine($"|**Date (UTC):** {session.Started.ToString(Constants.DateTimeFormat)}|**Time:** {TimeSpan.FromSeconds((int)((session.Finished == DateTimeOffset.MinValue ? DateTimeOffset.UtcNow : session.Finished) - session.Started).TotalSeconds)}|{(session.SpeedtestResult != null ? $"**Speed:** {(session.SpeedtestResult.DownloadedBytes > 0 ? $"{session.SpeedtestResult.MaxBytesPerSecond / (double)Constants.Megabyte :F2} MB/s ({session.SpeedtestResult.MaxBytesPerSecond / (double)Constants.Megabyte * 8 :F1} mbit)" : "Failed")}" : string.Empty)}|");
 
             if (onlyRedditStats || includeBanner)
             {

--- a/src/OpenDirectoryDownloader/Statistics.cs
+++ b/src/OpenDirectoryDownloader/Statistics.cs
@@ -108,7 +108,9 @@ namespace OpenDirectoryDownloader
                 stringBuilder.AppendLine($"|**Dirs:** {Library.FormatWithThousands(session.Root.TotalDirectories + 1)} **Ext:** {Library.FormatWithThousands(extensionsStats.Count)}|**Total:** {Library.FormatWithThousands(session.TotalFiles)}|**Total:** { (session.TotalFileSizeEstimated > 0 ? FileSizeHelper.ToHumanReadable(session.TotalFileSizeEstimated) : "n/a") }|");
             }
 
-            stringBuilder.AppendLine($"|**Date (UTC):** {session.Started.ToString(Constants.DateTimeFormat)}|**Time:** {TimeSpan.FromSeconds((int)((session.Finished == DateTimeOffset.MinValue ? DateTimeOffset.UtcNow : session.Finished) - session.Started).TotalSeconds)}|{(session.SpeedtestResult != null ? $"**Speed:** {(session.SpeedtestResult.DownloadedBytes > 0 ? $"{session.SpeedtestResult.MaxMBsPerSecond:F1} MB/s ({session.SpeedtestResult.MaxMBsPerSecond * 8:F0} mbit)" : "Failed")}" : string.Empty)}|");
+            // stringBuilder.AppendLine($"|**Date (UTC):** {session.Started.ToString(Constants.DateTimeFormat)}|**Time:** {TimeSpan.FromSeconds((int)((session.Finished == DateTimeOffset.MinValue ? DateTimeOffset.UtcNow : session.Finished) - session.Started).TotalSeconds)}|{(session.SpeedtestResult != null ? $"**Speed:** {(session.SpeedtestResult.DownloadedBytes > 0 ? $"{session.SpeedtestResult.MaxMBsPerSecond:F1} MB/s ({session.SpeedtestResult.MaxMBsPerSecond * 8:F0} mbit)" : "Failed")}" : string.Empty)}|");
+
+            stringBuilder.AppendLine($"|**Date (UTC):** {session.Started.ToString(Constants.DateTimeFormat)}|**Time:** {TimeSpan.FromSeconds((int)((session.Finished == DateTimeOffset.MinValue ? DateTimeOffset.UtcNow : session.Finished) - session.Started).TotalSeconds)}|{(session.SpeedtestResult != null ? $"**Speed:** {(session.SpeedtestResult.DownloadedBytes > 0 ? $"{FileSizeHelper.ToHumanReadable(session.SpeedtestResult.MaxBytesPerSecond):F1}/s ({FileSizeHelper.ToHumanReadable(session.SpeedtestResult.MaxBytesPerSecond * 8, true):F0}/s)" : "Failed")}" : string.Empty)}|");
 
             if (onlyRedditStats || includeBanner)
             {

--- a/src/OpenDirectoryDownloader/Statistics.cs
+++ b/src/OpenDirectoryDownloader/Statistics.cs
@@ -81,7 +81,7 @@ namespace OpenDirectoryDownloader
 
             if (session.Root.Url.Length < 40)
             {
-                stringBuilder.AppendLine($"|**Url:** {session.Root.Url}||{uploadedUrlsText}|");
+                stringBuilder.AppendLine($"|**Url:** [{session.Root.Url}]({session.Root.Url})||{uploadedUrlsText}|");
             }
             else
             {


### PR DESCRIPTION
The speedtest now uses Bytes instead of MB internally, and also uses `ToHumanReadable` to auto-format speeds.  

This should scale much better than the current implementation.

I tested it and this fixes #79, showing `**Speed:** 54,72 kiB/s (437,75 kib/s)` now instead of `0.0 MB/s (0 mbit)`.