### PR TITLE
Only apply the Content-Length fix to The Eye ODs

### DIFF
--- a/src/OpenDirectoryDownloader/Helpers/UrlHeaderInfoHelper.cs
+++ b/src/OpenDirectoryDownloader/Helpers/UrlHeaderInfoHelper.cs
@@ -50,7 +50,10 @@ namespace OpenDirectoryDownloader.Helpers
 
             try
             {
-                if (httpResponseMessage.Content?.Headers.ContentLength == null) {
+                if (
+                    (new Uri(url)).Host == "the-eye.eu" && // workaround until we come up with a better way to fix this **without slowing down scans of ODs that don't report `Content-Length` at all for some files** (e.g. .php, .html)
+                    httpResponseMessage.Content?.Headers.ContentLength == null
+                ) {
                     throw new Exception("Missing Content-Length header!");
                 }
                 return httpResponseMessage.Content?.Headers.ContentLength;


### PR DESCRIPTION
- for some ODs the fix caused scans to take much longer,
  because the server never returned the Content-Length header
  for some files (e.g. .php, .html)
- this should be fixed properly at some point 😅