### PR TITLE
Fix Warning SYSLIB0013: EscapeUriString is obsolete

### DIFF
--- a/src/OpenDirectoryDownloader.Tests/DirectoryParser000_025Tests.cs
+++ b/src/OpenDirectoryDownloader.Tests/DirectoryParser000_025Tests.cs
@@ -388,7 +388,7 @@ public class DirectoryParser000_025Tests : DirectoryParserTests
 	[Fact]
 	public async Task TestDirectoryListing13bAsync()
 	{
-		WebDirectory webDirectory = await ParseHtml(GetSample(), "https://thetrove.net/Assets/D&D%20Homebrew/index.html");
+		WebDirectory webDirectory = await ParseHtml(GetSample(), "https://thetrove.net/Assets/D&D Homebrew/index.html");
 
 		Assert.Equal(string.Empty, webDirectory.Name);
 		Assert.Equal(9, webDirectory.Subdirectories.Count);
@@ -405,7 +405,7 @@ public class DirectoryParser000_025Tests : DirectoryParserTests
 	[Fact]
 	public async Task TestDirectoryListing13cAsync()
 	{
-		WebDirectory webDirectory = await ParseHtml(GetSample(), "https://thetrove.net/Assets/Map%20Assets/2010-Fantasy/Fantasy/BearSkin%20Rug%20+%20Probonos%20hanging%20antelope/index.html");
+		WebDirectory webDirectory = await ParseHtml(GetSample(), "https://thetrove.net/Assets/Map Assets/2010-Fantasy/Fantasy/BearSkin Rug + Probonos hanging antelope/index.html");
 
 		Assert.Equal(string.Empty, webDirectory.Name);
 		Assert.Empty(webDirectory.Subdirectories);

--- a/src/OpenDirectoryDownloader.Tests/DirectoryParser101_125Tests.cs
+++ b/src/OpenDirectoryDownloader.Tests/DirectoryParser101_125Tests.cs
@@ -14,7 +14,7 @@ public class DirectoryParser101_125Tests : DirectoryParserTests
 	[Fact]
 	public async Task TestDirectoryListing101aAsync()
 	{
-		WebDirectory webDirectory = await ParseHtml(GetSample(), "https://thetrove.net/Books/Dungeons%20&%20Dragons/5th%20Edition%20(5e)/3rd%20Party/The%20Deck%20of%20Many/Deck%20of%20Many%20-%20Animated%20Spells%20Master%20V.02%20[Mar%202019]/");
+		WebDirectory webDirectory = await ParseHtml(GetSample(), "https://thetrove.net/Books/Dungeons & Dragons/5th Edition (5e)/3rd Party/The Deck of Many/Deck of Many - Animated Spells Master V.02 [Mar 2019]/");
 
 		Assert.Equal("Deck of Many - Animated Spells Master V.02 [Mar 2019]", webDirectory.Name);
 		Assert.Equal(2, webDirectory.Subdirectories.Count);

--- a/src/OpenDirectoryDownloader/DirectoryParser.cs
+++ b/src/OpenDirectoryDownloader/DirectoryParser.cs
@@ -685,7 +685,7 @@ public static class DirectoryParser
 
 	private static WebDirectory ParsePureDirectoryListing(ref string baseUrl, WebDirectory parsedWebDirectory, IHtmlDocument htmlDocument, IHtmlCollection<IElement> pureTableRows, bool checkParents)
 	{
-		string urlFromBreadcrumbs = Uri.EscapeUriString(string.Join("/", htmlDocument.QuerySelectorAll(".breadcrumbs_main .breadcrumb").Where(b => !b.ClassList.Contains("smaller")).Select(b => b.TextContent)) + "/");
+		string urlFromBreadcrumbs = Uri.EscapeDataString(string.Join("/", htmlDocument.QuerySelectorAll(".breadcrumbs_main .breadcrumb").Where(b => !b.ClassList.Contains("smaller")).Select(b => b.TextContent)) + "/");
 
 		// Remove possible file part (index.html) from url
 		if (!string.IsNullOrWhiteSpace(Path.GetFileName(WebUtility.UrlDecode(baseUrl))))
@@ -697,7 +697,7 @@ public static class DirectoryParser
 		string urlFromBaseUrl = baseUrl.Remove(0, new Uri(baseUrl).Scheme.Length + new Uri(baseUrl).Host.Length + 3).Replace("/.", "/");
 		urlFromBaseUrl = urlFromBaseUrl.Replace("%23", "#");
 
-		if (urlFromBreadcrumbs == urlFromBaseUrl || urlFromBreadcrumbs == Uri.EscapeUriString(urlFromBaseUrl))
+		if (urlFromBreadcrumbs == urlFromBaseUrl || urlFromBreadcrumbs == Uri.EscapeDataString(urlFromBaseUrl))
 		{
 			IElement table = pureTableRows.First().Parent("table");
 
@@ -716,7 +716,7 @@ public static class DirectoryParser
 				if (IsValidLink(link))
 				{
 					string linkHref = link.TextContent;
-					Uri uri = new Uri(new Uri(baseUrl), Uri.EscapeUriString(linkHref));
+					Uri uri = new Uri(new Uri(baseUrl), Uri.EscapeDataString(linkHref));
 					string fullUrl = uri.ToString();
 					string size = tableRow.QuerySelector($"td:nth-child({fileSizeHeaderColumnIndex})")?.TextContent.Trim();
 					bool isFile = !tableRow.ClassList.Contains("dir");

--- a/src/OpenDirectoryDownloader/UrlEncodingParser.cs
+++ b/src/OpenDirectoryDownloader/UrlEncodingParser.cs
@@ -121,7 +121,7 @@ public class UrlEncodingParser : NameValueCollection
 
 			foreach (string val in values)
 			{
-				query += $"{key}={Uri.EscapeUriString(val)}&";
+				query += $"{key}={Uri.EscapeDataString(val)}&";
 			}
 		}
 


### PR DESCRIPTION
Building with dotnet version 6.0.100 gives 4 warnings:
```
src/OpenDirectoryDownloader/UrlEncodingParser.cs(124,23): 
warning SYSLIB0013: 'Uri.EscapeUriString(string)' is obsolete: 
'Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components.'
```

According to the documentation:

>The Uri.EscapeUriString(String) API is marked as obsolete, starting in .NET
> 6. Using it in code generates warning SYSLIB0013 at compile time.
> Uri.EscapeUriString(String) can corrupt the Uri string in some cases.

~ https://docs.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0013
~ https://github.com/dotnet/runtime/issues/31387