### PR TITLE
Decode the urls before writing to outputfile

### DIFF
--- a/src/OpenDirectoryDownloader/Command.cs
+++ b/src/OpenDirectoryDownloader/Command.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using System.Net;
 using TextCopy;
 
 namespace OpenDirectoryDownloader;
@@ -196,8 +197,7 @@ public class Command
 			Logger.Info("Saving URL list to file..");
 			Console.WriteLine("Saving URL list to file..");
 
-			IEnumerable<string> distinctUrls = OpenDirectoryIndexer.Session.Root.AllFileUrls.Distinct();
-
+			IEnumerable<string> distinctUrls = OpenDirectoryIndexer.Session.Root.AllFileUrls.Distinct().Select(i => WebUtility.UrlDecode(i));
 			string urlsPath = Library.GetOutputFullPath(OpenDirectoryIndexer.Session, openDirectoryIndexer.OpenDirectoryIndexerSettings, "txt");
 			File.WriteAllLines(urlsPath, distinctUrls);
 

--- a/src/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
+++ b/src/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
@@ -367,7 +367,7 @@ public class OpenDirectoryIndexer
 				Session.TotalFiles = Session.Root.TotalFiles;
 				Session.TotalFileSizeEstimated = Session.Root.TotalFileSize;
 
-				IEnumerable<string> distinctUrls = Session.Root.AllFileUrls.Distinct();
+				IEnumerable<string> distinctUrls = Session.Root.AllFileUrls.Distinct().Select(i => WebUtility.UrlDecode(i));
 
 				if (Session.TotalFiles != distinctUrls.Count())
 				{
@@ -392,8 +392,8 @@ public class OpenDirectoryIndexer
 						try
 						{
 							string urlsPath = Library.GetOutputFullPath(Session, OpenDirectoryIndexerSettings, "txt");
-
 							File.WriteAllLines(urlsPath, distinctUrls);
+
 							Logger.Info($"Saved URL list to file: {urlsPath}");
 							Console.WriteLine($"Saved URL list to file: {urlsPath}");
 


### PR DESCRIPTION
Sometimes the url's in the output files are partially url encoded.

This fixes that by running all of them through `System.Net.WebUtility.UrlDecode()` before writing them out.