### PR TITLE
update(README.md): Building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ It will save the URLs files onto C:\\Scans (windows), or replace with a custom f
 
 1.  Install the newest .NET 7 SDK.
 2.  `git clone https://github.com/KoalaBear84/OpenDirectoryDownloader`
-3.  `cd OpenDirectoryDownloader/OpenDirectoryDownloader`
+3.  `cd OpenDirectoryDownloader/src`
 4.  `dotnet build .`
-5.  `cd bin/Debug/net7.0`
+5.  `cd OpenDirectoryDownloader/bin/Debug/net7.0`
 6.  `./OpenDirectoryDownloader --url "https://myopendirectory.com"`
 
 For Linux (Might not be needed since .NET 7):  


### PR DESCRIPTION
1. The directory `OpenDirectoryDownloader/OpenDirectoryDownloader` no longer exists, and it looks like it was swapped with `OpenDirectoryDownloader/src`. Updating the readme build instructions to reflect the change.

2. Swap `bin/Debug/net7.0`   with `OpenDirectoryDownloader/bin/Debug/net7.0`. Full path: `OpenDirectoryDownloader/src/OpenDirectoryDownloader/bin/Debug/net7.0`