### PR TITLE
Improve copyparty parser

### DIFF
--- a/src/OpenDirectoryDownloader/DirectoryParser.cs
+++ b/src/OpenDirectoryDownloader/DirectoryParser.cs
@@ -267,7 +267,7 @@ public static class DirectoryParser
 			}
 
 			// copyparty
-			if (htmlDocument.QuerySelector("div#ops") is not null)
+			if (htmlDocument.QuerySelector("#op_bup #u2err") is not null)
 			{
 				return ParseCopypartyListing(baseUrl, parsedWebDirectory, htmlDocument);
 			}
@@ -455,9 +455,8 @@ public static class DirectoryParser
 		{
 			IHtmlAnchorElement link = entry.QuerySelector("td:nth-child(2) a") as IHtmlAnchorElement;
 			IHtmlTableCellElement fileSize = entry.QuerySelector("td:nth-child(3)") as IHtmlTableCellElement;
-			IHtmlTableCellElement fileType = entry.QuerySelector("td:nth-child(4)") as IHtmlTableCellElement;
 
-			bool isDirectory = fileType.TextContent == "---";
+			bool isDirectory = link.TextContent.EndsWith("/");
 
 			if (link is not null)
 			{
@@ -479,7 +478,7 @@ public static class DirectoryParser
 					parsedWebDirectory.Files.Add(new WebFile
 					{
 						Url = fullUrl,
-						FileName = Path.GetFileName(WebUtility.UrlDecode(fullUrl)),
+						FileName = Path.GetFileName(WebUtility.UrlDecode(fullUrl.Split('?')[0])),
 						FileSize = FileSizeHelper.ParseFileSize(fileSize.TextContent)
 					});
 				}


### PR DESCRIPTION
On copyparty servers with media indexing enabled (`-e2ts`), there might be [additional columns](https://a.ocv.me/pub/demo/music/aivi%20%26%20surasshu%20-%20The%20Black%20Box/) with metadata between the filesize and filetype columns. So this PR changes the way it checks for folders, by looking for `/` at the end of link texts instead.

Another fix included here is for servers which enabled the filekeys feature; this makes the server generate and append passwords to the URLs in the form of `?k=...` which is now stripped away. I don't know of any public examples for this one tho :+1:

I've also changed the identifier it uses to detect copyparty, so there's less chance of any false positives. The new selector should work for all previous and future versions :>

And one more thing! I think some people disable their HTML listings with `--force-js`... The solution to that would be to request and parse the [json listings](https://a.ocv.me/pub/demo/music/aivi%20%26%20surasshu%20-%20The%20Black%20Box/?ls) instead, but that'd be a lot of work and probably not worth it hehe
