### PR TITLE
Attempted Fix For URLs Not Being Encoded Properly When Being Written to File #142

### DIFF
--- a/src/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
+++ b/src/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
@@ -499,7 +499,20 @@ public partial class OpenDirectoryIndexer
 						try
 						{
 							string urlsPath = Library.GetOutputFullPath(Session, OpenDirectoryIndexerSettings, "txt");
-							File.WriteAllLines(urlsPath, distinctUrls);
+							List<string> outputUrls = [];
+							foreach (string url in distinctUrls)
+							{
+								string safeUrl = url.Contains("#") ? url.Replace("#", "%23") : url;
+								if (Uri.TryCreate(safeUrl, UriKind.Absolute, out Uri uri))
+								{
+									outputUrls.Add(uri.AbsoluteUri);
+								}
+								else
+								{
+									outputUrls.Add(safeUrl);
+								}
+							}
+							File.WriteAllLines(urlsPath, outputUrls);
 
 							Program.Logger.Information("Saved URL list to file: {path}", urlsPath);
 							Console.WriteLine($"Saved URL list to file: {urlsPath}");
@@ -754,14 +767,21 @@ public partial class OpenDirectoryIndexer
 	private static void WriteAria2Urls(WebDirectory webDirectory, StreamWriter streamWriter)
 	{
 		foreach (WebFile webFile in webDirectory.Files)
-		{
-			streamWriter.WriteLine(webFile.Url);
+			{
+				string safeUrl = webFile.Url.Contains("#") ? webFile.Url.Replace("#", "%23") : webFile.Url;
+				if (Uri.TryCreate(safeUrl, UriKind.Absolute, out Uri uri))
+				{
+					streamWriter.WriteLine(uri.AbsoluteUri);
+				}
+				else
+				{
+					streamWriter.WriteLine(safeUrl);
+				}
 
-			string directory = webFile.Url[0..^webFile.FileName.Length].Replace(Session.Root.Url, string.Empty).TrimEnd('/');
-
-			streamWriter.WriteLine($"  dir={directory}");
-			streamWriter.WriteLine($"  out={webFile.FileName}");
-		}
+				string directory = webFile.Url[0..^webFile.FileName.Length].Replace(Session.Root.Url, string.Empty).TrimEnd('/');
+				streamWriter.WriteLine($"  dir={directory}");
+				streamWriter.WriteLine($"  out={webFile.FileName}");
+			}
 
 		foreach (WebDirectory subdirectory in webDirectory.Subdirectories)
 		{


### PR DESCRIPTION
This attempts to fix the URLs not being correctly written to files and when being passed to download tools like Aria2 them failing due to spaces etc not being correctly encoded. 

The fix consists of forcing # files to be re-encoded to %23 before continuing due to URLs with filenames containing a literal # not downloading correctly otherwise based on testing - (This is probably due to a literal hash symbol being typically reserved for fragments) It then reconstructs the URL using an Absolute URI. This handles issues like spaces and converting them to %20. It also has a fallback in case creating the URL fails.

This also attempts to unify the how running the tool with --url and having it automatically save a scan and manually saving a file with pressing U. I couldn't understand why both of them produced different formatting so I decided to make them as close as possible to each other.