### PR TITLE
Add options for Aria2 to output URL as a directory as well as specify a custom root directory

### DIFF
--- a/src/OpenDirectoryDownloader.Shared/Models/CommandLineOptions.cs
+++ b/src/OpenDirectoryDownloader.Shared/Models/CommandLineOptions.cs
@@ -31,6 +31,12 @@ public class CommandLineOptions
 	[Option('i', "aria2-urls", Required = false, Default = false, HelpText = "Save aria2 urls files (with directory support)")]
 	public bool Aria2UrlsFile { get; set; }
 
+	[Option("aria2-root-dir", Required = false, Default = "", HelpText = "Specify a root directory for aria2 urls files (with directory support) e.g. /dir/)]
+	public string Aria2RootDir { get; set; }
+
+	[Option("aria2-url-dir", Required = false, Default = false, HelpText = "Use URL as folder name for aria2 urls files (with directory support)")]
+	public bool Aria2UrlDir { get; set; }
+
 	[Option("no-browser", Required = false, Default = false, HelpText = "Do not launch browser (for cloudflare etc.)")]
 	public bool NoBrowser { get; set; }
 

--- a/src/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
+++ b/src/OpenDirectoryDownloader/OpenDirectoryIndexer.cs
@@ -558,15 +558,28 @@ public partial class OpenDirectoryIndexer
 					{
 						Program.Logger.Information("Saving aria2 URL list to file..");
 						Console.WriteLine("Saving aria2 URL list to file..");
-
+						
 						try
 						{
+							string rootDir = string.Empty;
+							string urlDir = string.Empty;
+							if (!string.IsNullOrWhiteSpace(OpenDirectoryIndexerSettings.CommandLineOptions.Aria2RootDir))
+							{
+								rootDir = OpenDirectoryIndexerSettings.CommandLineOptions.Aria2RootDir.TrimStart('/').TrimEnd('/');
+							}
+
 							string urlsPath = Library.GetOutputFullPath(Session, OpenDirectoryIndexerSettings, "txt");
+
+							if (OpenDirectoryIndexerSettings.CommandLineOptions.Aria2UrlDir)
+							{
+								urlDir = Path.GetFileNameWithoutExtension(urlsPath);
+							}
+
 							urlsPath = $"{Path.GetFileNameWithoutExtension(urlsPath)}-aria2.txt";
 							using FileStream fileStream = new(urlsPath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read, bufferSize: 1024 * 1024);
 							using StreamWriter streamWriter = new(fileStream);
 
-							WriteAria2Urls(Session.Root, streamWriter);
+							WriteAria2Urls(Session.Root, streamWriter, rootDir, urlDir);
 
 							Program.Logger.Information("Saved aria2 URL list to file: {path}", urlsPath);
 							Console.WriteLine($"Saved aria2 URL list to file: {urlsPath}");
@@ -751,21 +764,31 @@ public partial class OpenDirectoryIndexer
 		});
 	}
 
-	private static void WriteAria2Urls(WebDirectory webDirectory, StreamWriter streamWriter)
+	private static void WriteAria2Urls(WebDirectory webDirectory, StreamWriter streamWriter, string rootDir, string urlDir)
 	{
 		foreach (WebFile webFile in webDirectory.Files)
-		{
-			streamWriter.WriteLine(webFile.Url);
+			{
+				streamWriter.WriteLine(webFile.Url);
 
-			string directory = webFile.Url[0..^webFile.FileName.Length].Replace(Session.Root.Url, string.Empty).TrimEnd('/');
+				string directory = webFile.Url[0..^webFile.FileName.Length].Replace(Session.Root.Url, string.Empty).TrimEnd('/');
+				
+				if (!string.IsNullOrWhiteSpace(urlDir))
+				{
+					directory = Path.Combine(urlDir, directory.TrimStart('/').TrimEnd('/'));
+				}
 
-			streamWriter.WriteLine($"  dir={directory}");
-			streamWriter.WriteLine($"  out={webFile.FileName}");
-		}
+				if (!string.IsNullOrWhiteSpace(rootDir))
+				{
+					directory = Path.Combine(rootDir, directory.TrimStart('/').TrimEnd('/'));
+				}
+
+				streamWriter.WriteLine($"  dir={directory}");
+				streamWriter.WriteLine($"  out={webFile.FileName}");
+			}
 
 		foreach (WebDirectory subdirectory in webDirectory.Subdirectories)
 		{
-			WriteAria2Urls(subdirectory, streamWriter);
+			WriteAria2Urls(subdirectory, streamWriter, rootDir, urlDir);
 		}
 	}
 


### PR DESCRIPTION
As mentioned this introduces two new command line options that can be used in conjunction with aria2-urls that allow the user to: 
1. Use --aria2-root-dir to specify a root directory for URLs to be output such as /dir/. This is useful if a user wants to organise where their downloads are output (In my case I run aria2 in a docker container and without specifying the folder path first it dumps the output into the root of the filesystem which is not easily accessible)
2. Use --aria2-url-dir to use the URL as folder name. This uses the same formatted URL as the text file name to avoid issues with certain characters. Allows easier sorting if you are downloading multiple sites. 